### PR TITLE
Enhance bus stop map with tile options and clustering

### DIFF
--- a/make_map.py
+++ b/make_map.py
@@ -1,6 +1,7 @@
 import osmnx as ox
 import geopandas as gpd
 import folium
+from folium.plugins import MarkerCluster
 
 # Define the place and tags
 place = "Curitiba, Brazil"
@@ -18,21 +19,28 @@ gdf = gdf.to_crs(epsg=4326)
 centroid = gdf.unary_union.centroid
 center_latlon = [centroid.y, centroid.x]
 
-# Create a Folium map centered at the centroid
-m = folium.Map(location=center_latlon, zoom_start=zoom_level, tiles="CartoDB positron")
+# Create a Folium map centered at the centroid with multiple tile layers
+m = folium.Map(location=center_latlon, zoom_start=zoom_level, tiles=None)
+folium.TileLayer("CartoDB positron", name="CartoDB Positron").add_to(m)
+folium.TileLayer("OpenStreetMap", name="OpenStreetMap").add_to(m)
+folium.TileLayer(
+    "Stamen Terrain",
+    name="Stamen Terrain",
+    attr="Map tiles by Stamen Design, CC BY 3.0 — Map data © OpenStreetMap contributors",
+).add_to(m)
 
-# Add bus stop markers to the map
+# Add bus stop markers to the map using a MarkerCluster plugin
+marker_cluster = MarkerCluster().add_to(m)
 for _, row in gdf.iterrows():
     coords = row.geometry
     if coords.geom_type == 'Point':
-        folium.CircleMarker(
+        folium.Marker(
             location=[coords.y, coords.x],
-            radius=3,
-            color="blue",
-            fill=True,
-            fill_opacity=0.7,
             popup=row.get("name", description)
-        ).add_to(m)
+        ).add_to(marker_cluster)
+
+# Add layer control to toggle tile layers
+folium.LayerControl().add_to(m)
 
 # Save the map
 m.save("index.html")


### PR DESCRIPTION
## Summary
- Add OpenStreetMap and Stamen Terrain tile layers alongside CartoDB Positron
- Cluster bus stop markers using `MarkerCluster` and expose layer controls

## Testing
- `pip install -r requirements.txt`
- `python make_map.py`


------
https://chatgpt.com/codex/tasks/task_b_68bafad62d10832fba740c5832d6f0d9