### PR TITLE
Add optional administrative boundary polygon overlay

### DIFF
--- a/make_map.py
+++ b/make_map.py
@@ -58,6 +58,19 @@ interactive_layer = folium.GeoJson(
     popup=folium.GeoJsonPopup(fields=popup_fields, labels=True),
 ).add_to(m)
 
+# Try to fetch and display the administrative boundary polygon for the place.
+# OpenStreetMap uses the "admin_level" tag for such boundaries:
+# https://wiki.openstreetmap.org/wiki/Key:admin_level
+try:
+    boundary_gdf = ox.geocode_to_gdf(place).to_crs(epsg=4326)
+    folium.GeoJson(
+        boundary_gdf,
+        name="Boundary",
+        style_function=lambda x: {"fillOpacity": 0, "color": "green"},
+    ).add_to(m)
+except Exception:
+    pass
+
 # Add layer control to toggle tile layers
 folium.LayerControl().add_to(m)
 


### PR DESCRIPTION
## Summary
- display administrative boundary polygon for the selected place if it can be downloaded
- reference OpenStreetMap admin_level documentation for boundary tag context

## Testing
- `python make_map.py`
- `python -m py_compile make_map.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb4eb14388832f94dd080bada29add